### PR TITLE
Improve context management and add SQL query endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# Basic_Agent
+# Basic Agent
+
+This repository contains a prototype of a domain-focused data analyst agent. It
+provides a chat-based web interface backed by an LLM hosted on AWS Bedrock. The
+agent relies on domain documents and ingested CSV data tables to answer
+questions.
+
+## Features
+
+- Prompt templates describing the agent's purpose and available table schema.
+- Utilities for ingesting CSV files into a SQLite database.
+- FastAPI web application exposing `/chat` and `/query` endpoints.
+- Simple chat memory per session stored in memory with a configurable
+  context window size.
+- Helper utilities to run SQL queries with row limits to control context
+  length.
+- Placeholder integration with AWS Bedrock including logging and error handling.
+- Documentation outlining the architecture and future roadmap.
+
+## Setup
+
+1. Install Python 3.10 or newer.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Place CSV files inside a `data/` directory at the project root.
+4. Run `python -m agent_app.main` and navigate to `http://localhost:8000/docs`
+   to interact with the API.
+
+## Roadmap
+
+See `docs/roadmap.md` for planned enhancements including persistent chat
+storage, document retrieval, richer logging around AWS Bedrock calls, and
+authentication.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,23 @@
+# Architecture Overview
+
+This project aims to build a domain-specific data analyst agent that communicates
+via a web-based chat interface. The core components include:
+
+- **Web Framework**: A FastAPI application provides HTTP endpoints and auto-
+  generated docs. Uvicorn runs the server.
+- **State Management**: Chat history is stored in memory per session. Future
+  versions will persist this data in a database. A simple character-based limit
+  trims history to keep the context window manageable.
+- **Data Ingestion**: CSV files are loaded into a SQLite database. Schema
+  metadata from this database is supplied to the LLM to ground responses. SQL
+  queries are executed with a row limit so large result sets do not overflow the
+  context window.
+- **LLM Integration**: The agent calls AWS Bedrock (e.g., Claude v3) using
+  boto3. Logging and error handling capture request metadata and failures.
+- **Agent Logic**: `ChatAgent` composes prompts from the system description,
+  schema information, and conversation history before invoking Bedrock. Database
+  queries are executed through helper utilities that limit returned rows and
+  format results for the LLM.
+
+Future enhancements include authentication, richer logging, and expanded data
+sources.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,14 @@
+# Prompt Design
+
+Prompts guide the LLM on how to behave and what data is available.
+
+## System Prompt
+The system prompt summarizes the agent's role and the domain context. It is
+assembled using the `system_prompt` function in `agent_app.prompts` and is the
+first message sent to the LLM.
+
+## Schema Information
+When CSV files are ingested, their table names and columns are formatted with the
+`schema_prompt` function. This string is included when the `ChatAgent` composes
+a prompt so the LLM knows which tables are available and what columns they
+contain.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,12 @@
+# Roadmap
+
+1. **Prototype** - FastAPI chat UI with CSV ingestion and prompt generation.
+2. **Document/Data Retrieval** - Add search APIs for domain documents and table
+   queries.
+3. **State Management** - Persist conversation history and user sessions in a
+   database. Trim stored history to manage the LLM context window.
+4. **Logging & Error Handling** - Capture AWS Bedrock calls and gracefully
+   handle failures or rate limits.
+5. **Authentication** - Restrict access to data and documents based on user
+   roles and ensure data privacy.
+6. **Query Tools** - Provide SQL query APIs with row limits and summarization.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+boto3

--- a/src/agent_app/__init__.py
+++ b/src/agent_app/__init__.py
@@ -1,0 +1,18 @@
+"""Agent app package."""
+
+from .prompts import system_prompt, schema_prompt
+from .data_ingestion import ingest_csv_directory, schema_metadata
+from .llm import invoke_bedrock
+from .agent import ChatAgent
+from .database import execute_query, format_rows
+
+__all__ = [
+    "system_prompt",
+    "schema_prompt",
+    "ingest_csv_directory",
+    "schema_metadata",
+    "invoke_bedrock",
+    "ChatAgent",
+    "execute_query",
+    "format_rows",
+]

--- a/src/agent_app/agent.py
+++ b/src/agent_app/agent.py
@@ -1,0 +1,65 @@
+"""Simple chat agent that maintains conversation history and calls Bedrock."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+from pathlib import Path
+import logging
+
+from .prompts import system_prompt
+from .llm import invoke_bedrock
+from .database import execute_query, format_rows
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatAgent:
+    """LLM-powered chat agent."""
+
+    domain_description: str
+    schema_info: str
+    model_id: str
+    db_path: Path
+    max_history_chars: int = 8000
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+    def add_message(self, role: str, content: str) -> None:
+        self.history.append({"role": role, "content": content})
+        self._trim_history()
+
+    def _trim_history(self) -> None:
+        """Ensure the history stays within the max character limit."""
+        text = "\n".join(f"{m['role']}: {m['content']}" for m in self.history)
+        while len(text) > self.max_history_chars and self.history:
+            self.history.pop(0)
+            text = "\n".join(f"{m['role']}: {m['content']}" for m in self.history)
+
+    def build_prompt(self, user_message: str) -> str:
+        lines = [system_prompt(self.domain_description), self.schema_info]
+        for msg in self.history:
+            lines.append(f"{msg['role']}: {msg['content']}")
+        lines.append(f"user: {user_message}")
+        return "\n".join(lines)
+
+    def chat(self, message: str) -> str:
+        """Send a message to the agent and return the response."""
+        prompt = self.build_prompt(message)
+        try:
+            reply = invoke_bedrock(prompt, self.model_id)
+        except Exception as exc:  # pragma: no cover - runtime error path
+            logger.error("LLM call failed: %s", exc)
+            raise
+        self.add_message("user", message)
+        self.add_message("assistant", reply)
+        return reply
+
+    def query_db(self, sql: str, max_rows: int = 100) -> str:
+        """Execute a SQL query and return formatted results."""
+        try:
+            count, rows = execute_query(self.db_path, sql, max_rows)
+        except Exception as exc:  # pragma: no cover - runtime error path
+            logger.error("Query failed: %s", exc)
+            raise
+        return format_rows(count, rows, max_rows)

--- a/src/agent_app/data_ingestion.py
+++ b/src/agent_app/data_ingestion.py
@@ -1,0 +1,42 @@
+"""CSV ingestion and schema extraction utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Dict
+import csv
+
+
+def ingest_csv_directory(csv_dir: Path, db_path: Path) -> List[Dict[str, List[str]]]:
+    """Load all CSV files from csv_dir into a SQLite database at db_path.
+
+    Returns a list of schema dictionaries with table names and columns.
+    """
+    conn = sqlite3.connect(db_path)
+    schema_info = []
+    for csv_file in csv_dir.glob("*.csv"):
+        table_name = csv_file.stem
+        with open(csv_file, newline="") as f:
+            reader = csv.reader(f)
+            headers = next(reader)
+            columns_clause = ", ".join(f'"{col}" TEXT' for col in headers)
+            conn.execute(f'CREATE TABLE IF NOT EXISTS "{table_name}" ({columns_clause});')
+            for row in reader:
+                placeholders = ", ".join("?" for _ in row)
+                conn.execute(
+                    f'INSERT INTO "{table_name}" VALUES ({placeholders});',
+                    row,
+                )
+        schema_info.append({"name": table_name, "columns": headers})
+    conn.commit()
+    conn.close()
+    return schema_info
+
+
+def schema_metadata(csv_dir: Path, db_path: Path) -> str:
+    """Ingest CSVs, return formatted schema string for prompts."""
+    schema = ingest_csv_directory(csv_dir, db_path)
+    from .prompts import schema_prompt
+
+    return schema_prompt(schema)

--- a/src/agent_app/database.py
+++ b/src/agent_app/database.py
@@ -1,0 +1,39 @@
+"""SQLite database query helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+
+def execute_query(db_path: Path, query: str, limit: int = 100) -> Tuple[int, List[Dict[str, object]]]:
+    """Execute a SQL query with a row limit.
+
+    Returns the total number of rows the query would return and a limited
+    subset of rows as dictionaries.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        count_sql = f"SELECT COUNT(*) FROM ({query}) as sub"
+        row_count = conn.execute(count_sql).fetchone()[0]
+
+        limited_query = f"{query} LIMIT {limit}"
+        cur = conn.execute(limited_query)
+        columns = [col[0] for col in cur.description]
+        rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+    return row_count, rows
+
+
+def format_rows(row_count: int, rows: List[Dict[str, object]], limit: int) -> str:
+    """Format rows for display in the chat response."""
+    lines = [f"Row count: {row_count}"]
+    for row in rows:
+        parts = [f"{k}={v}" for k, v in row.items()]
+        lines.append(" | ".join(parts))
+    if row_count > len(rows):
+        lines.append(f"... {row_count - len(rows)} more rows")
+    return "\n".join(lines)

--- a/src/agent_app/llm.py
+++ b/src/agent_app/llm.py
@@ -1,0 +1,37 @@
+"""AWS Bedrock LLM invocation helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except Exception:  # pragma: no cover - boto3 may not be installed
+    boto3 = None
+    BotoCoreError = ClientError = Exception
+
+logger = logging.getLogger(__name__)
+
+
+def invoke_bedrock(prompt: str, model_id: str, *, max_tokens: int = 512, temperature: float = 0.1) -> str:
+    """Invoke an AWS Bedrock model and return the response text.
+
+    This function expects `boto3` to be configured with appropriate AWS
+    credentials and region. Errors are logged and re-raised.
+    """
+    if boto3 is None:
+        raise RuntimeError("boto3 is required to call Bedrock")
+
+    client = boto3.client("bedrock-runtime")
+    body = json.dumps({"prompt": prompt, "max_tokens_to_sample": max_tokens, "temperature": temperature})
+
+    try:
+        response = client.invoke_model(modelId=model_id, body=body, accept="application/json", contentType="application/json")
+        result = json.loads(response["body"].read())
+        return result.get("completion", "")
+    except (BotoCoreError, ClientError) as exc:
+        logger.error("Bedrock invocation failed: %s", exc)
+        raise

--- a/src/agent_app/main.py
+++ b/src/agent_app/main.py
@@ -1,0 +1,13 @@
+"""Entry point to run the FastAPI web application."""
+
+from __future__ import annotations
+
+import uvicorn
+
+
+def main() -> None:
+    uvicorn.run("agent_app.webapp:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_app/prompts.py
+++ b/src/agent_app/prompts.py
@@ -1,0 +1,25 @@
+"""Prompt templates for the LLM agent."""
+
+from typing import List
+
+
+def system_prompt(domain_description: str) -> str:
+    """Return the system prompt describing the agent's purpose."""
+    return (
+        "You are a data analyst assistant. "
+        f"Domain description: {domain_description}. "
+        "Use provided documents and data tables to answer questions."
+    )
+
+
+def schema_prompt(tables: List[dict]) -> str:
+    """Format table schema metadata for inclusion in prompts.
+
+    Args:
+        tables: List of dictionaries with keys 'name' and 'columns'.
+    """
+    lines = ["Available tables and columns:"]
+    for table in tables:
+        cols = ", ".join(table.get("columns", []))
+        lines.append(f"- {table['name']}: {cols}")
+    return "\n".join(lines)

--- a/src/agent_app/webapp.py
+++ b/src/agent_app/webapp.py
@@ -1,0 +1,77 @@
+"""FastAPI web application exposing a chat endpoint."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .data_ingestion import schema_metadata
+from .agent import ChatAgent
+from .database import execute_query
+
+logger = logging.getLogger(__name__)
+app = FastAPI(title="LLM Data Analyst")
+
+# In-memory store of agents per session ID
+_sessions: Dict[str, ChatAgent] = {}
+
+
+def get_agent(session_id: str) -> ChatAgent:
+    if session_id not in _sessions:
+        csv_dir = Path("data")
+        db_path = Path(f"{session_id}.db")
+        schema_info = schema_metadata(csv_dir, db_path)
+        agent = ChatAgent(
+            domain_description="Operations data analysis for the supply chain domain",
+            schema_info=schema_info,
+            model_id="anthropic.claude-v3",
+            db_path=db_path,
+        )
+        _sessions[session_id] = agent
+    return _sessions[session_id]
+
+
+class ChatRequest(BaseModel):
+    session_id: str
+    message: str
+
+
+class ChatResponse(BaseModel):
+    response: str
+
+
+class QueryRequest(BaseModel):
+    session_id: str
+    sql: str
+    limit: int = 100
+
+
+class QueryResponse(BaseModel):
+    row_count: int
+    rows: List[Dict[str, Any]]
+
+
+@app.post("/chat", response_model=ChatResponse)
+def chat(req: ChatRequest) -> ChatResponse:
+    agent = get_agent(req.session_id)
+    try:
+        reply = agent.chat(req.message)
+    except Exception as exc:  # pragma: no cover - runtime error path
+        logger.error("Chat failed: %s", exc)
+        raise HTTPException(status_code=500, detail="LLM call failed")
+    return ChatResponse(response=reply)
+
+
+@app.post("/query", response_model=QueryResponse)
+def query(req: QueryRequest) -> QueryResponse:
+    agent = get_agent(req.session_id)
+    try:
+        count, rows = execute_query(agent.db_path, req.sql, req.limit)
+    except Exception as exc:  # pragma: no cover - runtime error path
+        logger.error("Query failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Query failed")
+    return QueryResponse(row_count=count, rows=rows)


### PR DESCRIPTION
## Summary
- refine features in README and architecture docs
- trim conversation history in `ChatAgent`
- add SQLite query helpers with row-limit enforcement
- expose new `/query` FastAPI endpoint
- document roadmap additions

## Testing
- `PYTHONPATH=src python -m agent_app.main` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_684a5bbfafd083308a965e28acebf488